### PR TITLE
Implement trait `versionize::Versionize` for arrays `[T; $size]

### DIFF
--- a/coverage_config_aarch64.json
+++ b/coverage_config_aarch64.json
@@ -1,1 +1,1 @@
-{"coverage_score": 92.8, "exclude_path": "", "crate_features": ""}
+{"coverage_score": 92.7, "exclude_path": "", "crate_features": ""}

--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,1 +1,1 @@
-{"coverage_score": 93.0, "exclude_path": "", "crate_features": ""}
+{"coverage_score": 93.2, "exclude_path": "", "crate_features": ""}

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -636,11 +636,13 @@ fn test_versionize_struct_with_array() {
     struct TestStruct {
         a: [u32; SIZE],
         b: [u8; dummy_mod::SIZE],
+        c: Option<[i16; SIZE]>,
     }
 
     let test_struct = TestStruct {
         a: [1; SIZE],
         b: [2; dummy_mod::SIZE],
+        c: Some([3; SIZE]),
     };
 
     let mut mem = vec![0; 4096];


### PR DESCRIPTION
Signed-off-by: Ioana Chirca <chioana@amazon.com>

## Reason for This PR

Fixes #2

## Description of Changes

The trait is implemented only for arrays of up to 32 elements, following the [convention](https://doc.rust-lang.org/std/primitive.array.html) 

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
