### PR TITLE
Display for VersionizeError and Versionize for tuple of 2 elems

### DIFF
--- a/coverage_config_aarch64.json
+++ b/coverage_config_aarch64.json
@@ -1,2 +1,1 @@
-{"coverage_score": 91.2, "exclude_path": "", "crate_features": ""}
-
+{"coverage_score": 92.8, "exclude_path": "", "crate_features": ""}

--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,2 +1,1 @@
-{"coverage_score": 92.2, "exclude_path": "", "crate_features": ""}
-
+{"coverage_score": 93.0, "exclude_path": "", "crate_features": ""}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,6 +42,18 @@ pub enum VersionizeError {
     Semantic(String),
 }
 
+impl std::fmt::Display for VersionizeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::result::Result<(), std::fmt::Error> {
+        use VersionizeError::*;
+        match self {
+            Io(e) => write!(f, "An IO error occured: {}", e),
+            Serialize(e) => write!(f, "A serialization error occured: {}", e),
+            Deserialize(e) => write!(f, "A deserialization error occured: {}", e),
+            Semantic(e) => write!(f, "A user generated semantic error occured: {}", e),
+        }
+    }
+}
+
 /// Versioned serialization/deserialization result.
 pub type VersionizeResult<T> = std::result::Result<T, VersionizeError>;
 
@@ -75,4 +87,18 @@ pub trait Versionize {
 
     /// Returns latest `Self` version number.
     fn version() -> u16;
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_error_debug_display() {
+        // Validates Debug and Display are implemented.
+        use VersionizeError::*;
+        let str = String::from("test");
+        format!("{:?}{}", Io(0), Io(0));
+        format!("{:?}{}", Serialize(str.clone()), Serialize(str.clone()));
+        format!("{:?}{}", Deserialize(str.clone()), Deserialize(str.clone()));
+        format!("{:?}{}", Semantic(str.clone()), Semantic(str.clone()));
+    }
 }


### PR DESCRIPTION
## Reason for This PR

Prerequisite for https://github.com/firecracker-microvm/firecracker/issues/1829

## Description of Changes

 - implement fmt::Display for VersionizeError
 - implement Versionize for tuple of 2 elems

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
