### PR TITLE
Improve edge cases handling for Vec (de)serialize

### DIFF
--- a/coverage_config_aarch64.json
+++ b/coverage_config_aarch64.json
@@ -1,1 +1,1 @@
-{"coverage_score": 92.3, "exclude_path": "", "crate_features": ""}
+{"coverage_score": 92.7, "exclude_path": "", "crate_features": ""}

--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,1 +1,1 @@
-{"coverage_score": 93.0, "exclude_path": "", "crate_features": ""}
+{"coverage_score": 92.9, "exclude_path": "", "crate_features": ""}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,9 +63,9 @@ impl std::fmt::Display for VersionizeError {
             ),
             VecLength(bad_len) => write!(
                 f,
-                "Vec length exceeded {} > {} bytes",
+                "Vec of length {} exceeded maximum size of {} bytes",
                 bad_len,
-                primitives::MAX_VEC_LEN
+                primitives::MAX_VEC_SIZE
             ),
         }
     }


### PR DESCRIPTION
Signed-off-by: Luminita Voicu <lumivo@amazon.com>

## Reason for This PR

Multiplication for computing Vec's size in bytes fails with overflow error.

## Description of Changes

Added a check for overflow during multiplication for both serialize and deserialize functions.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The reason for this PR is clearly provided (issue no. or explanation).
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
