### PR TITLE
Validate root_version before using it as index.

### DIFF
--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,1 +1,1 @@
-{"coverage_score": 92.9, "exclude_path": "", "crate_features": ""}
+{"coverage_score": 93.0, "exclude_path": "", "crate_features": ""}


### PR DESCRIPTION
## Reason for This PR

Validate root_version against the latest version in get_type_version().

## Description of Changes

- get_type_version() now returns latest version when root_version is out
of bounds
- Add negative unit test

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
