### PR TITLE
remove dependency on vm-memory

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ serde_derive = ">=1.0.27"
 bincode = "1.2.1"
 versionize_derive = ">=0.1.1"
 crc64 = "1.0.0"
-vm-memory = { version = ">=0.2.0" }
 vmm-sys-util = ">=0.4.0"
 
 [build-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,6 @@ extern crate crc64;
 extern crate serde;
 extern crate serde_derive;
 extern crate versionize_derive;
-extern crate vm_memory;
 extern crate vmm_sys_util;
 
 pub mod crc;


### PR DESCRIPTION
It doesn't look like it is needed anymore.
Fixes: https://github.com/firecracker-microvm/versionize/issues/12

Signed-off-by: Andreea Florescu <fandree@amazon.com>

## Reason for This PR

`[Author TODO: add issue # or explain reasoning.]`

## Description of Changes

`[Author TODO: add description of changes.]`

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The reason for this PR is clearly provided (issue no. or explanation).
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
