### PR TITLE
add versionize for VecDequeue/HashMap/HashSet.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v0.1.5
+
+- Add versionize proc macro support for HashMap, HashSet and VecDequeue.
+
 # v0.1.4
 
 - Removed Versionize proc macro support for unions. Serializing unions can lead to undefined behaviour especially when no

--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,1 +1,1 @@
-{"coverage_score": 93.2, "exclude_path": "", "crate_features": ""}
+{"coverage_score": 93.3, "exclude_path": "", "crate_features": ""}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@
 //! The Versionize proc macro supports structures and enums.
 //! Supported primitives: u8, u16, u32, u64, usize, i8, i16, i32, i64, isize, char, f32, f64,
 //! String, Vec<T>, Arrays up to 32 elements, Box<T>, Wrapping<T>, Option<T>, FamStructWrapper<T>,
-//! and (T, U).
+//! VecDequeue<T>, HashMap<K, V>, HashSet<T> and (T, U).
 //!
 //! Known issues and limitations:
 //! - Union serialization is not supported via the `Versionize` proc macro.
@@ -54,6 +54,10 @@ pub enum VersionizeError {
     StringLength(usize),
     /// Vector length exceeded.
     VecLength(usize),
+    /// HashMap length exceeded.
+    HashMapLength(usize),
+    /// HashSet length exceeded.
+    HashSetLength(usize),
 }
 
 impl std::fmt::Display for VersionizeError {
@@ -76,6 +80,18 @@ impl std::fmt::Display for VersionizeError {
                 "Vec of length {} exceeded maximum size of {} bytes",
                 bad_len,
                 primitives::MAX_VEC_SIZE
+            ),
+            HashMapLength(bad_len) => write!(
+                f,
+                "HashMap of length {} exceeded maximum size of {} bytes",
+                bad_len,
+                primitives::MAX_HASH_MAP_SIZE
+            ),
+            HashSetLength(bad_len) => write!(
+                f,
+                "HashSet of length {} exceeded maximum size of {} bytes",
+                bad_len,
+                primitives::MAX_HASH_SET_SIZE
             ),
         }
     }


### PR DESCRIPTION
Signed-off-by: JasonBian<zizheng.bian@linux.alibaba.com>

## Reason for This PR

Added support for some of the commonly used data structures: VecDeque, HashMap, and HashSet

## Description of Changes

- Add versionize support for new types in `primitives.rs`.
- Add Error arms for new types in `lib.rs`.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The reason for this PR is clearly provided (issue no. or explanation).
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
