### PR TITLE
Update rust-vmm-ci

### DIFF
--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -166,11 +166,12 @@ macro_rules! impl_versionize_arrays {
     }
 }
 
+#[allow(clippy::reversed_empty_ranges)]
 impl_versionize_arrays! {
-    0  1  2  3  4  5  6  7  8  9
-   10 11 12 13 14 15 16 17 18 19
-   20 21 22 23 24 25 26 27 28 29
-   30 31 32
+    1  2  3  4  5  6  7  8  9 10
+   11 12 13 14 15 16 17 18 19 20
+   21 22 23 24 25 26 27 28 29 30
+   31 32
 }
 
 impl<T> Versionize for Box<T>


### PR DESCRIPTION
24d66cd update clippy check
ebc7016 exclude dependabot from the 50/72 commit rule
63fdf0f update rust-vmm-container
98a26fe Typo fix in README.md
631c82a mount tmp in test pipelines
03fcf08 don't run commit test for repos specified with git
3b7377c fixed typo in readme
c9430ee add gitignore file
e1108f1 buildkite: re-enable cargo audit test
02004b5 Add a flag that saves the coverage output dir
97025bd buildkite: Skip lines should be shorter than 70 chars
c83003c buildkite: Skip cargo audit check temporarily
c8cf2b7 buildkite: Fix audit label indentation
b3acb30 Fixes: https://github.com/rust-vmm/rust-vmm-ci/issues/8
bedc32b Add --workspace flag to cargo check too
3ea5f2b improve a bit error messages for commit test
cd90a63 Add support for workspace tests
9dd386c readme update: cosmetic changes
265df53 Coverage test: keep stdin open
2d3bb05 add myself to codeowners

Signed-off-by: berciuliviu <lberciu@amazon.com>

## Reason for This PR

Update rust-vmm-ci.

## Description of Changes

Updated rust-vmm-ci crate using the guide [here](https://github.com/rust-vmm/community/blob/master/CONTRIBUTING.md#updating-the-rust-vmm-ci).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The reason for this PR is clearly provided (issue no. or explanation).
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
