### PR TITLE
Enhance VersionMap to filter out some versions

### DIFF
--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,1 +1,1 @@
-{"coverage_score": 95.4, "exclude_path": "test", "crate_features": ""}
+{"coverage_score": 96.2, "exclude_path": "test", "crate_features": ""}


### PR DESCRIPTION
## Reason for This PR

#33 

## Description of Changes

Current VersionMap implementation assumes all versions lower than
VersionMap::latest_version() are supported. That may not be true in
some situation. So add `is_supported()` method to VersionMap to
filter out some versions.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x ] All commits in this PR are signed (`git commit -s`).
- [ x] The reason for this PR is clearly provided (issue no. or explanation).
- [ x] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
