### PR TITLE
Release 0.1.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
+# v0.1.7
+
+- Use caret requirements instead of comparison requirements
+  for specifying dependencies
+- Update vmm-sys-utils to 0.11.0
+
 # v0.1.6
 
-- Upraded vmm-sys-utils to v0.8.0
+- Upgraded vmm-sys-utils to v0.8.0
 
 # v0.1.5
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "versionize"
-version = "0.1.6"
+version = "0.1.7"
 license = "Apache-2.0"
 authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
 description = "A version tolerant serialization/deserialization framework."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,17 +10,17 @@ keywords = ["serialization", "version"]
 categories = ["encoding"]
 
 [dependencies]
-serde = ">=1.0.27"
-serde_derive = ">=1.0.27"
+serde = "1.0.27"
+serde_derive = "1.0.27"
 bincode = "1.2.1"
-versionize_derive = ">=0.1.3"
+versionize_derive = "0.1.4"
 crc64 = "1.0.0"
-vmm-sys-util = ">=0.8.0"
+vmm-sys-util = "0.11.0"
 
 [build-dependencies]
-proc-macro2 = ">=1.0"
-quote = ">=1.0"
-syn = { version = ">=1.0.13", features=["default","full"]}
+proc-macro2 = "1.0"
+quote = "1.0"
+syn = { version = "1.0.13", features=["default","full"]}
 
 [badges]
 maintenance = { status = "experimental" }

--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,1 +1,1 @@
-{"coverage_score": 96.2, "exclude_path": "test", "crate_features": ""}
+{"coverage_score": 92.4, "exclude_path": "test", "crate_features": ""}

--- a/src/crc.rs
+++ b/src/crc.rs
@@ -146,7 +146,7 @@ mod tests {
 
         let mut slice = buf.as_mut_slice();
         let mut crc_writer = CRC64Writer::new(&mut slice);
-        crc_writer.write_all(&write_buf.as_slice()).unwrap();
+        crc_writer.write_all(write_buf.as_slice()).unwrap();
         crc_writer.flush().unwrap();
         assert_eq!(crc_writer.checksum(), 0x29D5_3572_1632_6566);
         assert_eq!(crc_writer.checksum(), crc_writer.crc64);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,6 @@
 //! extensive testing.
 //! - Semantic serialization and deserialization is available only for
 //! structures.
-//!
 extern crate bincode;
 extern crate crc64;
 extern crate serde;
@@ -107,7 +106,7 @@ pub type VersionizeResult<T> = std::result::Result<T, VersionizeError>;
 ///
 /// impl<T> Versionize for MyType<T>
 /// where
-/// T: Versionize,
+///     T: Versionize,
 /// {
 ///     #[inline]
 ///     fn serialize<W: std::io::Write>(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,6 +45,7 @@ pub use version_map::VersionMap;
 use versionize_derive::Versionize;
 
 /// Versioned serialization/deserialization error definitions.
+#[allow(clippy::derive_partial_eq_without_eq)] // FIXME: next major release
 #[derive(Debug, PartialEq)]
 pub enum VersionizeError {
     /// An IO error occured.

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -481,7 +481,7 @@ mod tests {
             <String as Versionize>::deserialize(&mut buffer.as_slice().split_at(6).0, &vm, 1)
                 .unwrap_err(),
             VersionizeError::Deserialize(
-                "Io(Custom { kind: UnexpectedEof, error: \"failed to fill whole buffer\" })"
+                "Io(Error { kind: UnexpectedEof, message: \"failed to fill whole buffer\" })"
                     .to_owned()
             )
         );
@@ -519,7 +519,7 @@ mod tests {
             <Vec<u8> as Versionize>::deserialize(&mut buffer.as_slice().split_at(6).0, &vm, 1)
                 .unwrap_err(),
             VersionizeError::Deserialize(
-                "Io(Custom { kind: UnexpectedEof, error: \"failed to fill whole buffer\" })"
+                "Io(Error { kind: UnexpectedEof, message: \"failed to fill whole buffer\" })"
                     .to_owned()
             )
         );

--- a/src/version_map.rs
+++ b/src/version_map.rs
@@ -278,10 +278,10 @@ mod tests {
         let mut vm = VersionMap::default();
         vm.new_version();
 
-        assert_eq!(vm.is_supported(0), false);
-        assert_eq!(vm.is_supported(1), true);
-        assert_eq!(vm.is_supported(2), true);
-        assert_eq!(vm.is_supported(3), false);
+        assert!(!vm.is_supported(0));
+        assert!(vm.is_supported(1));
+        assert!(vm.is_supported(2));
+        assert!(!vm.is_supported(3));
 
         let mut vm = VersionMap::with_filter(Arc::new(MyFilter));
         vm.new_version();
@@ -291,13 +291,13 @@ mod tests {
         vm.new_version();
 
         let vm1 = vm.clone();
-        assert_eq!(vm1.is_supported(0), false);
-        assert_eq!(vm1.is_supported(1), true);
-        assert_eq!(vm1.is_supported(2), true);
-        assert_eq!(vm1.is_supported(3), true);
-        assert_eq!(vm1.is_supported(4), true);
-        assert_eq!(vm1.is_supported(5), false);
-        assert_eq!(vm1.is_supported(6), false);
+        assert!(!vm1.is_supported(0));
+        assert!(vm1.is_supported(1));
+        assert!(vm1.is_supported(2));
+        assert!(vm1.is_supported(3));
+        assert!(vm1.is_supported(4));
+        assert!(!vm1.is_supported(5));
+        assert!(!vm1.is_supported(6));
         assert_eq!(vm.latest_version(), 6);
     }
 }

--- a/src/version_map.rs
+++ b/src/version_map.rs
@@ -47,7 +47,6 @@
 //! assert_eq!(version_map.get_type_version(1, Struct2::type_id()), 1);
 //! assert_eq!(version_map.get_type_version(1, State::type_id()), 1);
 //!
-//!
 //! // Check that root version 2 has Struct1 at version 2 and Struct2
 //! // at version 1.
 //! assert_eq!(version_map.get_type_version(2, Struct1::type_id()), 2);

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -151,7 +151,7 @@ fn test_hardcoded_struct_deserialization() {
         option_1: Option<u8>,
         #[version(start = 3, end = 4, default_fn = "default_vec")]
         vec_1: Vec<char>,
-        #[allow(clippy::box_collection)]  // we want to explicitly test Box
+        #[allow(clippy::box_collection)] // we want to explicitly test Box
         box_1: Box<String>,
         #[version(start = 3)]
         wrapping_1: Wrapping<u32>,
@@ -635,8 +635,7 @@ impl Device {
         // Fail if semantic serialization is called for a version >= 2.
         assert!(target_version < 2);
         self.some_params.push("active".to_owned());
-        self.some_params
-            .retain(|x| x.clone() != *"inactive");
+        self.some_params.retain(|x| x.clone() != *"inactive");
         Ok(())
     }
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,6 +1,8 @@
 // Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+#![allow(clippy::missing_safety_doc)]
+
 extern crate versionize;
 extern crate versionize_derive;
 extern crate vmm_sys_util;
@@ -14,7 +16,7 @@ use vmm_sys_util::generate_fam_struct_impl;
 use versionize::{VersionMap, Versionize, VersionizeError, VersionizeResult};
 use versionize_derive::Versionize;
 
-#[derive(Debug, PartialEq, Versionize)]
+#[derive(Debug, PartialEq, Versionize, Eq)]
 pub enum TestState {
     Zero,
     One(u32),
@@ -149,6 +151,7 @@ fn test_hardcoded_struct_deserialization() {
         option_1: Option<u8>,
         #[version(start = 3, end = 4, default_fn = "default_vec")]
         vec_1: Vec<char>,
+        #[allow(clippy::box_collection)]  // we want to explicitly test Box
         box_1: Box<String>,
         #[version(start = 3)]
         wrapping_1: Wrapping<u32>,
@@ -353,7 +356,7 @@ fn test_hardcoded_enum_deserialization() {
     );
 }
 
-#[derive(Debug, PartialEq, Versionize)]
+#[derive(Debug, PartialEq, Eq, Versionize)]
 pub struct A {
     a: u32,
     #[version(start = 1, end = 2)]
@@ -362,7 +365,7 @@ pub struct A {
     c: String,
 }
 
-#[derive(Debug, PartialEq, Versionize)]
+#[derive(Debug, PartialEq, Eq, Versionize)]
 pub struct X {
     x: bool,
     a_1: A,
@@ -380,7 +383,7 @@ impl A {
 
 impl X {
     fn default_y(_source_version: u16) -> Box<usize> {
-        Box::from(4 as usize)
+        Box::from(4)
     }
 
     fn default_z(_source_version: u16) -> Vec<u8> {
@@ -441,7 +444,7 @@ fn test_nested_structs_deserialization() {
             b: Some(TestState::One(4)),
             c: "some_string".to_owned(),
         },
-        y: Box::from(2 as usize),
+        y: Box::from(2),
         z: vec![16, 4],
     };
     assert_eq!(restored_state, expected_state);
@@ -458,7 +461,7 @@ fn test_nested_structs_deserialization() {
             b: None,
             c: "random".to_owned(),
         },
-        y: Box::from(2 as usize),
+        y: Box::from(2),
         z: vec![16, 4],
     };
     assert_eq!(restored_state, expected_state);
@@ -475,7 +478,7 @@ fn test_nested_structs_deserialization() {
             b: None,
             c: "random".to_owned(),
         },
-        y: Box::from(4 as usize),
+        y: Box::from(4),
         z: vec![24; 4],
     };
     assert_eq!(restored_state, expected_state);
@@ -514,7 +517,7 @@ fn test_versionize_struct_with_array() {
     assert_eq!(restored_test_struct, test_struct);
 }
 
-#[derive(Clone, Debug, PartialEq, Versionize)]
+#[derive(Clone, Debug, PartialEq, Eq, Versionize)]
 pub enum DeviceStatus {
     Inactive,
     Active,
@@ -528,7 +531,7 @@ impl Default for DeviceStatus {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Versionize)]
+#[derive(Clone, Debug, PartialEq, Eq, Versionize)]
 pub enum OperationSupported {
     Add,
     Remove,
@@ -567,7 +570,7 @@ impl OperationSupported {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Versionize)]
+#[derive(Clone, Debug, PartialEq, Eq, Versionize)]
 pub struct Device {
     name: String,
     id: Wrapping<u32>,
@@ -633,7 +636,7 @@ impl Device {
         assert!(target_version < 2);
         self.some_params.push("active".to_owned());
         self.some_params
-            .retain(|x| x.clone() != "inactive".to_owned());
+            .retain(|x| x.clone() != *"inactive");
         Ok(())
     }
 
@@ -782,7 +785,7 @@ fn test_versionize_struct_with_enums() {
     );
 }
 
-#[derive(Clone, Debug, PartialEq, Versionize)]
+#[derive(Clone, Debug, PartialEq, Eq, Versionize)]
 pub enum State {
     Zero,
     One(bool),

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1182,7 +1182,7 @@ fn test_versionize_struct() {
             .serialize(&mut snapshot_mem.as_mut_slice(), &vm, 1)
             .unwrap_err(),
         VersionizeError::Serialize(
-            "Io(Custom { kind: WriteZero, error: \"failed to write whole buffer\" })".to_owned()
+            "Io(Error { kind: WriteZero, message: \"failed to write whole buffer\" })".to_owned()
         )
     );
     snapshot_mem = vec![0u8; 256];
@@ -1196,7 +1196,8 @@ fn test_versionize_struct() {
     assert_eq!(
         <Test as Versionize>::deserialize(&mut snapshot_mem.as_slice(), &vm, 1).unwrap_err(),
         VersionizeError::Deserialize(
-            "Io(Custom { kind: UnexpectedEof, error: \"failed to fill whole buffer\" })".to_owned()
+            "Io(Error { kind: UnexpectedEof, message: \"failed to fill whole buffer\" })"
+                .to_owned()
         )
     );
 }
@@ -1432,7 +1433,7 @@ fn test_versionize_famstructwrapper() {
             .serialize(&mut snapshot_mem.as_mut_slice(), &vm, 1)
             .unwrap_err(),
         VersionizeError::Serialize(
-            "Io(Custom { kind: WriteZero, error: \"failed to write whole buffer\" })".to_owned()
+            "Io(Error { kind: WriteZero, message: \"failed to write whole buffer\" })".to_owned()
         )
     );
 }


### PR DESCRIPTION
## Reason for This PR

See https://github.com/rust-vmm/community/issues/136

## Description of Changes

Fix Cargo.toml to use caret reqs instead of comparison reqs and update rust-vmm/vmm-sys-util to 0.11.0

This PR is based on https://github.com/firecracker-microvm/versionize/pull/43, which should be merged first. All changes in that PR have been made in a way that ensures we hold the contract of a patch release

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
