### PR TITLE
Fix VersionMap no longer being Send+Sync

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "versionize"
-version = "0.1.7"
+version = "0.1.8"
 license = "Apache-2.0"
 authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
 description = "A version tolerant serialization/deserialization framework."

--- a/src/version_map.rs
+++ b/src/version_map.rs
@@ -83,7 +83,7 @@ impl VersionFilter for () {
 #[derive(Clone, Debug)]
 pub struct VersionMap {
     versions: Vec<HashMap<TypeId, u16>>,
-    filter: Arc<dyn VersionFilter>,
+    filter: Arc<dyn VersionFilter + Send + Sync>,
 }
 
 impl Default for VersionMap {
@@ -102,7 +102,7 @@ impl VersionMap {
     }
 
     /// Create a new version map with specified version filter.
-    pub fn with_filter(filter: Arc<dyn VersionFilter>) -> Self {
+    pub fn with_filter(filter: Arc<dyn VersionFilter + Send + Sync>) -> Self {
         VersionMap {
             versions: vec![HashMap::new(); 1],
             filter,
@@ -218,6 +218,13 @@ mod tests {
             assert_eq!(vm.get_type_version(i, TypeId::of::<MySecondType>()), i + 1);
             assert_eq!(vm.get_type_version(i, TypeId::of::<MyThirdType>()), i + 2);
         }
+    }
+
+    #[test]
+    fn test_version_map_is_send_and_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+
+        assert_send_sync::<VersionMap>();
     }
 
     #[test]


### PR DESCRIPTION
I overlooked that e00a8b52997a1bbb6c9baf35154feefed2c47076 was not part of 0.1.6 and introduced a breaking change, as the `dyn VersionFilter` field prevented `VersionMap` from being sharable between threads. As this was previously the case, this meant a breaking change snuck into a patch release, so 0.1.7 was yanked and instead we need to release 0.1.8

Signed-off-by: Patrick Roy <roypat@amazon.co.uk>


## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
