### PR TITLE
Implement versionize for arrays via const generics

### DIFF
--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -114,66 +114,44 @@ impl Versionize for String {
         1
     }
 }
-
-macro_rules! impl_versionize_array_with_size {
-    ($ty:literal) => {
-        impl<T> Versionize for [T; $ty]
-        where
-            T: Copy + Default + Versionize,
-        {
-            #[inline]
-            fn serialize<W: std::io::Write>(
-                &self,
-                writer: &mut W,
-                version_map: &VersionMap,
-                app_version: u16,
-            ) -> VersionizeResult<()> {
-                for element in self {
-                    element.serialize(writer, version_map, app_version)?;
-                }
-
-                Ok(())
-            }
-
-            #[inline]
-            fn deserialize<R: std::io::Read>(
-                reader: &mut R,
-                version_map: &VersionMap,
-                app_version: u16,
-            ) -> VersionizeResult<Self> {
-                let mut array = [T::default(); $ty];
-                for i in 0..$ty {
-                    array[i] = T::deserialize(reader, version_map, app_version)?;
-                }
-                Ok(array)
-            }
-
-            // Not used yet.
-            fn version() -> u16 {
-                1
-            }
+    
+impl<T, const N: usize> Versionize for [T; N]
+where
+    T: Copy + Default + Versionize,
+{
+    #[inline]
+    fn serialize<W: std::io::Write>(
+        &self,
+        writer: &mut W,
+        version_map: &VersionMap,
+        app_version: u16,
+    ) -> VersionizeResult<()> {
+        for element in self {
+            element.serialize(writer, version_map, app_version)?;
         }
-    };
-}
 
-// Conventionally, traits are available for primitive arrays only up to size 32
-// until the const generics feature is implemented.
-// [https://doc.rust-lang.org/std/primitive.array.html]
-// [https://github.com/rust-lang/rust/issues/44580]
-macro_rules! impl_versionize_arrays {
-    ($($N:literal)+) => {
-        $(
-            impl_versionize_array_with_size!($N);
-        )+
+        Ok(())
+    }
+
+    #[inline]
+    fn deserialize<R: std::io::Read>(
+        reader: &mut R,
+        version_map: &VersionMap,
+        app_version: u16,
+    ) -> VersionizeResult<Self> {
+        let mut array = [T::default(); N];
+        for i in 0..N {
+            array[i] = T::deserialize(reader, version_map, app_version)?;
+        }
+        Ok(array)
+    }
+
+    // Not used yet.
+    fn version() -> u16 {
+        1
     }
 }
 
-impl_versionize_arrays! {
-    1  2  3  4  5  6  7  8  9 10
-   11 12 13 14 15 16 17 18 19 20
-   21 22 23 24 25 26 27 28 29 30
-   31 32
-}
 
 impl<T> Versionize for Box<T>
 where

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -114,7 +114,7 @@ impl Versionize for String {
         1
     }
 }
-    
+
 impl<T, const N: usize> Versionize for [T; N]
 where
     T: Copy + Default + Versionize,
@@ -140,8 +140,8 @@ where
         app_version: u16,
     ) -> VersionizeResult<Self> {
         let mut array = [T::default(); N];
-        for i in 0..N {
-            array[i] = T::deserialize(reader, version_map, app_version)?;
+        for elem in &mut array {
+            *elem = T::deserialize(reader, version_map, app_version)?;
         }
         Ok(array)
     }
@@ -151,7 +151,6 @@ where
         1
     }
 }
-
 
 impl<T> Versionize for Box<T>
 where

--- a/src/version_map.rs
+++ b/src/version_map.rs
@@ -89,7 +89,7 @@ pub struct VersionMap {
 impl Default for VersionMap {
     fn default() -> Self {
         VersionMap {
-            versions: vec![HashMap::new(); 1],
+            versions: vec![HashMap::new()],
             filter: Arc::new(()),
         }
     }
@@ -104,7 +104,7 @@ impl VersionMap {
     /// Create a new version map with specified version filter.
     pub fn with_filter(filter: Arc<dyn VersionFilter + Send + Sync>) -> Self {
         VersionMap {
-            versions: vec![HashMap::new(); 1],
+            versions: vec![HashMap::new()],
             filter,
         }
     }


### PR DESCRIPTION
Signed-off-by: Patrick Roy <roypat@amazon.co.uk>

## Reason for This PR

resolves a TODO. const generics have been stablized since 1.51

## Description of Changes

Remove the macro generated impls up to array size 32 with a completely generic version based on const generics

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
