### PR TITLE
Update rust-vmm-ci submodule to newest version

### DIFF
--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -654,7 +654,7 @@ mod tests {
             _box: Box::new("Box".to_owned()),
         };
 
-        bincode::serialize_into(&mut snapshot_mem.as_mut_slice(), &test_struct).unwrap();
+        bincode::serialize_into(snapshot_mem.as_mut_slice(), &test_struct).unwrap();
 
         let restored_state: TestCompatibility =
             Versionize::deserialize(&mut snapshot_mem.as_slice(), &vm, 1).unwrap();


### PR DESCRIPTION
Signed-off-by: Patrick Roy <roypat@amazon.co.uk>

## Reason for This PR

The CI kept timing out due to epoll_wait's timing behavior changing. rust-vmm-ci fixed this by increasing the default timeout. See https://github.com/rust-vmm/rust-vmm-ci/pull/116/commits/dbb2e7f0b209db51d6ab7cebebdb2fac3870fe2b

## Description of Changes

Update rust-vmm-ci submodule

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
