### PR TITLE
Add missing bounds check to `<FamStructWrapper as Versionize>::deserialize`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v0.1.10
+
+- Fixed a possible out of bounds memory access in FamStructWrapper::deserialize
+
 # v0.1.9
 
 - Implement Versionize for i128 and u128

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "versionize"
-version = "0.1.9"
+version = "0.1.10"
 license = "Apache-2.0"
 authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
 description = "A version tolerant serialization/deserialization framework."

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -369,6 +369,18 @@ where
         let entries: Vec<<T as FamStruct>::Entry> =
             Vec::deserialize(reader, version_map, app_version)
                 .map_err(|ref err| VersionizeError::Deserialize(format!("{:?}", err)))?;
+
+        if header.len() != entries.len() {
+            let msg = format!(
+                "Mismatch between length of FAM specified in FamStruct header ({}) \
+                and actual size of FAM ({})",
+                header.len(),
+                entries.len()
+            );
+
+            return Err(VersionizeError::Deserialize(msg));
+        }
+
         // Construct the object from the array items.
         // Header(T) fields will be initialized by Default trait impl.
         let mut object = FamStructWrapper::from_entries(&entries)


### PR DESCRIPTION
An issue was discovered in the `Versionize::deserialize` implementation provided by the `versionize` crate for `vmm_sys_utils::fam::FamStructWrapper`, which can lead to out of bounds memory accesses. Objects of this type are used to model structures containing C-style flexible array members [[1]]. These structures contain a memory allocation that is prefixed by a header containing the size of the allocation.

Due to treating the header and the memory allocation as two objects, `Versionize`'s data format stores the size of the allocation twice: once in the header and then again as its own metadata of the memory allocation. A serialized `FamStructWrapper` thus looks as follows: 

```
+------------------------------------------------------------++---------------------------------------+-----------------------+
| header (containing length of flexible array member `len1`) || length of flexible array member`len2` | array member contents |
+------------------------------------------------------------++---------------------------------------+-----------------------+
```

During deserialization, the library separately deserializes the header and the memory allocation. It allocates `len2` bytes of memory, and then prefixes it with the separately deserialized header. Since `len2` is an implementation detail of the `Versionize` implementation, it is forgotten about at the end of the deserialize `function`, and all subsequent operations on the `FamStructWrapper` assume the memory allocated to have size `len1`. If deserialization input was malformed such that `len1 != len2`, then this can lead to (safe) functions on `FamStructWrapper` to read past the end of allocated memory (if `len1 > len2`). 

The issue was corrected by inserting a check that verifies that these two lengths are equal, and aborting deserialization otherwise. 

[1]: https://en.wikipedia.org/wiki/Flexible_array_member

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
