### PR TITLE
Cargo.toml: Update crc64 to 2.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ serde = "1.0.27"
 serde_derive = "1.0.27"
 bincode = "1.2.1"
 versionize_derive = "0.1.4"
-crc64 = "1.0.0"
+crc64 = "2.0.0"
 vmm-sys-util = "0.11.0"
 
 [build-dependencies]


### PR DESCRIPTION
## Reason for This PR

The `crc64-1.0.0` crate (currently 7+ years old) uses unsafe conversions that produce bad results on non-little-endian platforms.  This updates to the latest version (from a year ago) that fixes those issues.

## Description of Changes

The change just bumps the dependency version number.

It looks like its only changes to functions used by `versionize` is that it switches to safe conversions internally, and all tests pass with the update.  This is the full version diff to verify: https://github.com/badboy/crc64-rs/compare/v1.0.0...v2.0.0#files_bucket

I don't see any history saying why 1.0.0 would be required specifically, and #36 also suggested this change is acceptable.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

## PR Checklist

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.