### PR TITLE
fix: `missing_debug_implementations`

### DIFF
--- a/src/crc.rs
+++ b/src/crc.rs
@@ -5,6 +5,7 @@
 //! read/written.
 
 use crc64::crc64;
+use std::fmt;
 use std::io::{Read, Write};
 
 /// Computes the CRC64 checksum of the read bytes.
@@ -27,6 +28,12 @@ use std::io::{Read, Write};
 pub struct CRC64Reader<T> {
     reader: T,
     crc64: u64,
+}
+
+impl<T> fmt::Debug for CRC64Reader<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "CRC64Reader {{ .. }}")
+    }
 }
 
 impl<T> CRC64Reader<T>
@@ -74,6 +81,12 @@ where
 pub struct CRC64Writer<T> {
     writer: T,
     crc64: u64,
+}
+
+impl<T> fmt::Debug for CRC64Writer<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "CRC64Writer {{ .. }}")
+    }
 }
 
 impl<T> CRC64Writer<T>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 // Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-#![deny(missing_docs)]
+#![deny(missing_docs, missing_debug_implementations)]
 
 //! Defines a generic interface for version tolerant serialization and
 //! implements it for primitive data types using `bincode` as backend.


### PR DESCRIPTION
## Reason for This PR

When tracing/logging/debugging a program it is common to debug print inputs and outputs of function, to do this generally dependencies need to offer `std::fmt::Debug` implementations.

I won't repeat what is written under [`missing_debug_implementations`](https://doc.rust-lang.org/rustc/lints/listing/allowed-by-default.html#missing-debug-implementations) which gives some more explanation.

## Description of Changes

Sets `missing_debug_implementations` to deny and adds missing `std::fmt::Debug` implementations.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
