### PR TITLE
Add tests for more complicated expressions as the array size field.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["encoding"]
 serde = "1.0.27"
 serde_derive = "1.0.27"
 bincode = "1.2.1"
-versionize_derive = "0.1.4"
+versionize_derive = "0.1.6"
 crc64 = "2.0.0"
 vmm-sys-util = "0.11.0"
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -485,6 +485,7 @@ fn test_nested_structs_deserialization() {
 }
 
 pub const SIZE: usize = 10;
+pub const SIZE_U8: u8 = 15;
 
 pub mod dummy_mod {
     pub const SIZE: usize = 20;
@@ -497,12 +498,14 @@ fn test_versionize_struct_with_array() {
         a: [u32; SIZE],
         b: [u8; dummy_mod::SIZE],
         c: Option<[i16; SIZE]>,
+        d: [u8; SIZE_U8 as usize],
     }
 
     let test_struct = TestStruct {
         a: [1; SIZE],
         b: [2; dummy_mod::SIZE],
         c: Some([3; SIZE]),
+        d: [4; SIZE_U8 as usize],
     };
 
     let mut mem = vec![0; 4096];


### PR DESCRIPTION
## Reason for This PR

As part of https://github.com/firecracker-microvm/firecracker/pull/3557#issuecomment-1686610219, I'd like to change the types of some of the size constants currently used as array length expressions from `usize` to fixed-size types like `u8` or `u16`. Rust needs these to be explicitly casted to `usize` when they're used, but that causes an error with `#[derive(Versionize)]` because the size currently needs to be either a literal value or a constant.

## Description of Changes

[This PR](https://github.com/firecracker-microvm/versionize_derive/pull/24) changes the size field to accept any expression that's valid in an array size expression to also be accepted by `#[derive(Versionize)]`. This PR adds tests for that change.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
