### PR TITLE
Update vmm-sys-util to 0.12.0 and prepare 0.2.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v0.2.0
+
+- Implement `Versionize` for arrays of arbitrary length, instead of just up to 32.
+
 # v0.1.10
 
 - Fixed a possible out of bounds memory access in FamStructWrapper::deserialize

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "versionize"
-version = "0.1.10"
+version = "0.2.0"
 license = "Apache-2.0"
 authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
 description = "A version tolerant serialization/deserialization framework."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ serde_derive = "1.0.27"
 bincode = "1.2.1"
 versionize_derive = "0.1.6"
 crc64 = "2.0.0"
-vmm-sys-util = "0.11.0"
+vmm-sys-util = "0.12.1"
 
 [build-dependencies]
 proc-macro2 = "1.0"

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -362,8 +362,12 @@ where
         // Header(T) fields will be initialized by Default trait impl.
         let mut object = FamStructWrapper::from_entries(&entries)
             .map_err(|ref err| VersionizeError::Deserialize(format!("{:?}", err)))?;
-        // Update Default T with the deserialized header.
-        *object.as_mut_fam_struct() = header;
+        // SAFETY: We check above that the length in the header matches the number of elements
+        // in the FAM.
+        unsafe {
+            // Update Default T with the deserialized header.
+            *object.as_mut_fam_struct() = header;
+        }
         Ok(object)
     }
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,6 +1,7 @@
 // Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+#![allow(clippy::undocumented_unsafe_blocks)]
 #![allow(clippy::missing_safety_doc)]
 
 extern crate versionize;
@@ -1363,9 +1364,11 @@ fn test_versionize_famstructwrapper() {
         .set_type_version(Message::type_id(), 4);
 
     let mut state = MessageFamStructWrapper::new(0).unwrap();
-    state.as_mut_fam_struct().padding = 8;
-    state.as_mut_fam_struct().extra_value = 16;
-    state.as_mut_fam_struct().status = Wrapping(true);
+    unsafe {
+        state.as_mut_fam_struct().padding = 8;
+        state.as_mut_fam_struct().extra_value = 16;
+        state.as_mut_fam_struct().status = Wrapping(true);
+    }
 
     state.push(1).unwrap();
     state.push(2).unwrap();
@@ -1482,8 +1485,10 @@ pub struct FamStructTest {
 impl FamStructTest {
     fn default_message(_target_version: u16) -> Vec<MessageFamStructWrapper> {
         let mut f = MessageFamStructWrapper::new(0).unwrap();
-        f.as_mut_fam_struct().padding = 1;
-        f.as_mut_fam_struct().extra_value = 2;
+        unsafe {
+            f.as_mut_fam_struct().padding = 1;
+            f.as_mut_fam_struct().extra_value = 2;
+        }
 
         f.push(10).unwrap();
         f.push(20).unwrap();
@@ -1508,8 +1513,10 @@ impl FamStructTest {
         assert!(target_version < 2);
 
         let mut f = MessageFamStructWrapper::new(0).unwrap();
-        f.as_mut_fam_struct().padding = 3;
-        f.as_mut_fam_struct().extra_value = 4;
+        unsafe {
+            f.as_mut_fam_struct().padding = 3;
+            f.as_mut_fam_struct().extra_value = 4;
+        }
 
         f.push(10).unwrap();
         f.push(20).unwrap();
@@ -1532,13 +1539,17 @@ fn test_versionize_struct_with_famstructs() {
     let mut snapshot_mem = vec![0u8; 1024];
 
     let mut f = MessageFamStructWrapper::new(0).unwrap();
-    f.as_mut_fam_struct().padding = 5;
-    f.as_mut_fam_struct().extra_value = 6;
+    unsafe {
+        f.as_mut_fam_struct().padding = 5;
+        f.as_mut_fam_struct().extra_value = 6;
+    }
     f.push(10).unwrap();
 
     let mut f2 = MessageFamStructWrapper::new(0).unwrap();
-    f2.as_mut_fam_struct().padding = 7;
-    f2.as_mut_fam_struct().extra_value = 8;
+    unsafe {
+        f2.as_mut_fam_struct().padding = 7;
+        f2.as_mut_fam_struct().extra_value = 8;
+    }
     f2.push(20).unwrap();
 
     let state = FamStructTest {
@@ -1614,7 +1625,9 @@ impl SomeStruct {
     fn ser_u16(&mut self, target_version: u16) -> VersionizeResult<()> {
         // Fail if semantic serialization is called for the latest version.
         assert!(target_version < 2);
-        self.message.as_mut_fam_struct().padding += 2;
+        unsafe {
+            self.message.as_mut_fam_struct().padding += 2;
+        }
 
         Ok(())
     }
@@ -1631,7 +1644,9 @@ impl SomeStruct2 {
     fn ser_u16(&mut self, target_version: u16) -> VersionizeResult<()> {
         // Fail if semantic serialization is called for the latest version.
         assert!(target_version < 2);
-        self.message.as_mut_fam_struct().padding += 2;
+        unsafe {
+            self.message.as_mut_fam_struct().padding += 2;
+        }
 
         Ok(())
     }
@@ -1648,7 +1663,7 @@ fn test_famstructwrapper_clone() {
     vm.new_version().set_type_version(SomeStruct::type_id(), 2);
 
     let mut f = MessageFamStructWrapper::new(0).unwrap();
-    f.as_mut_fam_struct().padding = 8;
+    unsafe { f.as_mut_fam_struct().padding = 8 };
 
     f.push(1).unwrap();
     f.push(2).unwrap();


### PR DESCRIPTION
Update to 0.12.0 to prevent `cargo audit` from complaining about https://github.com/rust-vmm/vmm-sys-util/security/advisories/GHSA-875g-mfp6-g7f9, which `versionize` is not affected by (due to not using the `with-serde` feature flag). We need a 0.2.0 release because vmm-sys-util's API is exposed by means of the `Versionize` trait being implement for its types.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The reason for this PR is clearly provided (issue no. or explanation).
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
